### PR TITLE
Use rubygem-json for CentOS 7.x

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,23 @@ class ec2tagfacts::params {
   $aws_cli_ini_settings   = '/root/.aws/credentials'
 
   case $::operatingsystem {
-    'RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL': {
+    'CentOS': {
+      case $::operatingsystemrelease {
+        /^7.*/: {
+          $pippkg       = 'python-pip'
+          $rubyjsonpkg  = 'rubygem-json'
+          $awscli       = 'awscli'
+          $enable_epel  = true
+        }
+        default: {
+          $pippkg       = 'python-pip'
+          $rubyjsonpkg  = 'ruby-json'
+          $awscli       = 'awscli'
+          $enable_epel  = true
+        }
+      }
+    }
+    'RedHat', 'Fedora', 'Scientific', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL': {
       $pippkg       = 'python-pip'
       $rubyjsonpkg  = 'ruby-json'
       $awscli       = 'awscli'


### PR DESCRIPTION
Apparently CentOS 7.x changed ruby-json to rubygem-json.
