### PR TITLE
Update ec2_tag_facts.rb

### DIFF
--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -53,7 +53,7 @@ else
   #
 
   begin
-    jsonString = `aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region}`
+    jsonString = `aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json`
     #puts "JSON is...\n#{jsonString}"
     hash = JSON.parse(jsonString)
 


### PR DESCRIPTION
Forcing to json output for the aws command, the issue is present in some servers with text output by default.
