### PR TITLE
Fixed space substitution + changed to match all non-word chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This turns EC2 instance tags into puppet facts. For example: `ec2_tag_*tagname*`
 
 ### What ec2tagfacts affects
 
-* Tag names are prepended with `ec2_tag_`, converted to all lowercase, and spaces are converted to underscores.
+* Tag names are prepended with `ec2_tag_`, converted to all lowercase, and non-word character are converted to underscores.
 * You can now use EC2 tags in puppet classes, for example `$::ec2_tag_name`.
 * EC2 tags are then added to facter.
 * Python pip is installed in order to install the aws cli tool with pip.

--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -67,7 +67,7 @@ else
 
           fact = "ec2_tag_#{child['Key']}"
           fact.downcase!
-          fact.gsub(/\s+/, "_")
+          fact.gsub!(/\W+/, "_")
           #puts "Setting fact #{fact} to #{child['Value']}"
 
           Facter.add("#{fact}") do


### PR DESCRIPTION
Fixed replacement by underscore and now matching all non-word chars.
This is useful for ec2-generated tags like 'aws:autoscaling:groupName'
