### PR TITLE
Make disable of pkg mgmt for ruby-json-package possible via rubyjsonp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Optional. String/false. Autodetected in ec2tagfacts::params based on OS family. 
 
 Optional. String. Autodetected in ec2tagfacts::params based on OS family. You can override that with the parameter or in hiera. This is the awscli package provider to use. Python pip is used to install awscli unless a platform package is available.
 
+#####`rubyjsonpkg`
+
+Optional. String. Autodetected in ec2tagfacts::params based on OS family. You can override that with the parameter or in hiera. This is the Ruby JSON package name to use. To disable
+management of this package, set to false.
+
+
 ## RSpec Testing
 
 If bundle isn't already installed it is generally installed with `gem install bundle`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@
 #
 # [*rubyjsonpkg*]
 #   Set in ec2tagfacts::params, this is the ruby-json package name.
+#   False disables ruby-json package package management.
 #
 # === Examples
 #
@@ -109,7 +110,7 @@ class ec2tagfacts (
 
   }
 
-  if $rubyjsonpkg != undef {
+  if $rubyjsonpkg != false {
     package { 'ruby-json-package':
       ensure => 'installed',
       name   => $rubyjsonpkg,

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -44,6 +44,28 @@ describe 'ec2tagfacts' do
     end
   end
 
+  context 'supported operating systems disable rubyjsonpkg mgmt' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+        let(:params) do
+          {
+            'rubyjsonpkg' => false,
+          }
+        end
+        context "ec2tagfacts class disable rubyjsonpkg mgmt" do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('ec2tagfacts') }
+          it { is_expected.to contain_class('ec2tagfacts::params') }
+          it { is_expected.to contain_package('awscli') }
+          it { is_expected.not_to contain_package('ruby-json-package') }
+        end
+      end
+    end
+  end
+
   context 'unsupported operating system' do
     describe 'ec2tagfacts class without any parameters on Solaris/Nexenta' do
       let(:facts) do


### PR DESCRIPTION
…kg param

This is required if that package is managed elsewhere (with another
name) in your puppet tree. For example, The Foreman puppet module.