### PR TITLE
Multiple attempts to re-run 'aws ec2 describe-tags' due to API rate limit

### DIFF
--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -90,8 +90,14 @@ else
 
   begin
 
-    # This is why aws cli is required
-    jsonString = `aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json`
+    # Some edge cases may require multiple attempts to re-run 'aws ec2 describe-tags' due to API rate limits
+    # Making up to 6 attempts with sleep time ranging between 4-10 seconds after each unsuccessful attempt
+    for i in 1..6
+      # This is why aws cli is required
+      jsonString = `aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json`
+      break if jsonString != ''
+      sleep rand(4..10)
+    end
 
     debug_msg("JSON is...\n#{jsonString}")
 


### PR DESCRIPTION
Hi there,

I found that in some edge cases `ec2tagfacts` module does not work when API rate limit for `ec2 describe-tags` is reached.

As a workaround I suggest to make up to 6 attempts to re-rerun `aws cli` command with sleep time ranging between 4-10 seconds after each unsuccessful attempt.

Tested with ~250 parallel executions and it appears to be working fine.

Thanks!