### PR TITLE
On AmazonLinux: test for $::operatingsystemmajrelease

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class ec2tagfacts::params {
     }
     'Amazon': {
       # Test for Amazon Linux 2
-      if $::kernelrelease =~ /.*amzn2.*/ {
+      if $::operatingsystemmajrelease == '2' {
         $rubyjsonpkg  = 'rubygem-json'
         $pippkg       = 'python2-pip'
         $awscli       = 'awscli'


### PR DESCRIPTION
During my tests the regex test for "amzn2" within the kernel release constantly failed and yum failed trying to install the wrong rubygem18-json.
I'd like to propose using the value of $::operatingsystemmajrelease == '2' as an indicator for amazon linux 2.