### PR TITLE
For machines without permission bail out immediately

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Cliff Wakefield
 Davi Koscianski Vidal
 Roi Rav-Hon
 Tom
+Robert Hafner (tedivm@tedivm.com)

--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -13,6 +13,8 @@ require "net/http"
 require 'json' # hint: yum install ruby-json, or apt-get install ruby-json
 require "uri"
 require "date"
+require 'open3'
+
 
 # if set, file will be appended to with debug data
 #$debug = "/tmp/ec2_tag_facts.log"

--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -94,7 +94,13 @@ else
     # Making up to 6 attempts with sleep time ranging between 4-10 seconds after each unsuccessful attempt
     for i in 1..6
       # This is why aws cli is required
-      jsonString = `aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json`
+      jsonString, stderr_str, status = Open3.capture3('aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json')
+
+      # If the instance does not have permission this will never work
+      if stderr_str.include? "UnauthorizedOperation" then
+        debug_msg("Instance does not have permission to access its tags")
+        return
+      end
       break if jsonString != ''
       sleep rand(4..10)
     end

--- a/lib/facter/ec2_tag_facts.rb
+++ b/lib/facter/ec2_tag_facts.rb
@@ -96,7 +96,8 @@ else
     # Making up to 6 attempts with sleep time ranging between 4-10 seconds after each unsuccessful attempt
     for i in 1..6
       # This is why aws cli is required
-      jsonString, stderr_str, status = Open3.capture3('aws ec2 describe-tags --filters "Name=resource-id,Values=#{instance_id}" --region #{region} --output json')
+      debug_msg("aws ec2 describe-tags --filters \"Name=resource-id,Values=#{instance_id}\" --region #{region} --output json")
+      jsonString, stderr_str, status = Open3.capture3("aws ec2 describe-tags --filters \"Name=resource-id,Values=#{instance_id}\" --region #{region} --output json")
 
       # If the instance does not have permission this will never work
       if stderr_str.include? "UnauthorizedOperation" then


### PR DESCRIPTION
Right now the fact will attempt to run six times, with a random delay between each. This PR makes looks at the reason why the attempt failed, and if it is due to an authorization issue (ie, the instance doesn't have permission to grab the tags) then it stops after the first request.

I'm already running this in production and it works. I've attempted to run your testsuite using the 'vagrant' option, but my vagrant install tells me that the box being used for those tests is broken so it won't run. Running the lint and syntax checks showed no issues.