### PR TITLE
change to behaviour of the ec2facts process

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Cliff Wakefield
 Davi Koscianski Vidal
 Roi Rav-Hon
 Tom
+Freibuis <https://github.com/freibuis>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class ec2tagfacts (
   $awscli                 = $ec2tagfacts::params::awscli,
   $rubyjsonpkg            = $ec2tagfacts::params::rubyjsonpkg,
   $awscli_pkg             = $ec2tagfacts::params::awscli_pkg,
+  Boolean $facter_enable  = true,
 
 ) inherits ec2tagfacts::params {
 
@@ -124,18 +125,31 @@ class ec2tagfacts (
     }
   }
 
+  $directory = dirname($aws_cli_ini_settings)
+  file { $directory:
+    ensure  => directory,
+    recurse => true,
+  }
+
+  $facter_endable_flag = "${directory}/.ec2tags_enabled"
+
+  if $facter_enable {
+    $facter_ensure = 'present'
+  } else {
+    $facter_ensure = 'absent'
+  }
+
+  file {$facter_endable_flag:
+    ensure => $facter_ensure
+  }
+
   if ($aws_secret_access_key != undef) and ($aws_access_key_id != undef) {
 
-    $directory = dirname($aws_cli_ini_settings)
-    file { $directory:
-      ensure  => directory,
-      require => Package[$awscli],
-      recurse => true,
-    }
+
     ini_setting { 'aws_access_key_id setting':
       ensure  => present,
       path    => $aws_cli_ini_settings,
-      section => 'default',
+      section => 'puppet_ec2tags',
       setting => 'aws_access_key_id',
       value   => $aws_access_key_id,
       require => File[$directory],
@@ -143,12 +157,22 @@ class ec2tagfacts (
     ini_setting { 'aws_secret_access_key setting':
       ensure  => present,
       path    => $aws_cli_ini_settings,
-      section => 'default',
+      section => 'puppet_ec2tags',
       setting => 'aws_secret_access_key',
       value   => $aws_secret_access_key,
       require => File[$directory],
     }
 
+    $use_credentials_file = 'present'
+
+  } else {
+
+    $use_credentials_file = 'absent'
+
+  }
+
+  file {"${directory}/.ectags_use_credentials_file":
+    ensure => $use_credentials_file,
   }
 
 }


### PR DESCRIPTION
**_If you add this module to a control repo. the fact will fire on all machines even if the class is not declared._**  at this point tje resources have not already been deployed.. example awscli and creds
this module will break nodes that are
* on aws but do not have creds
* on aws already using default creds (default profile collision)
* not on aws (longer facter runs) (well sort of because of http lookup failure)

**_what this pull request hopes to achieve is to_**
* if using creds file do not use [default] profile instead use --profile=puppet_ec2tags and move the creds into that section of the config
* tell facter to use --profile=puppet_ec2tags if file `/root/.aws/.ectags_use_credentials_file` exists
* adds an ability to disable facter from being fired. ( via `/root/.aws/.ec2tags_enabled` file) meaning it will not run unless this class has been declared or the admin has declared they want it.


The downside to this is that facter will not get ec2_tags the first time around. 
The upside is that it will deploy faster first time and no prfile cred collisons

